### PR TITLE
Don't pass files generated in OUTPUT_DIR/public to rollup build config

### DIFF
--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -49,6 +49,7 @@ class EleventyVite {
 
       viteOptions.build.rollupOptions.input = input
         .filter(entry => !!entry.outputPath) // filter out `false` serverless routes
+        .filter(entry => !entry.outputPath.startsWith(this.outputDir + path.sep + 'public')) // filter out files in public/, vite/rollup will not touch these files and just copy them to the root of your output folder
         .map(entry => {
           if(!entry.outputPath.startsWith(this.outputDir + path.sep)) {
             throw new Error(`Unexpected output path (was not in output directory ${this.outputDir}): ${entry.outputPath}`);


### PR DESCRIPTION
I was tinkering with this plugin and came across issues with a generated sitemap.xml and robots.txt. 
When building, rollup breaks on sitemap.xml. If I leave out the sitemap and just build with robots.txt then an empty javascript bundle is created for robots.txt and robots.txt itself is gone.
To fix this mattrossman suggested outputting these files to OUTDIR/public and that fixes the robots.txt issue, but rollup still breaks on sitemap.xml.
These files should not be passed on to rollup.
So, an extra filter is needed to prevent files in OUTDIR/public to be passed to viteOptions.build.rollupOptions.input.

Disclaimer: first time I do a pull request and a bit tired :) Much love for 11ty!