### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ module.exports = function(eleventyConfig) {
       clearScreen: false,
       server: {
         mode: "development",
-        middlewareMode: "ssr",
+        middlewareMode: "true",
       },
+      appType: "custom",
       build: {
         mode: "production",
       }


### PR DESCRIPTION
Change from Vite 2 –> 3.0: 
Setting server.middlewareMode to 'ssr' is now deprecated. server.middlewareMode should be set to `true` and appType to 'custom' instead. Also see: https://vitejs.dev/guide/ssr.html#setting-up-the-dev-server
Tested this successfully with https://github.com/matthiasott/eleventy-plus-vite