### PR TITLE
Update default vite options for Vite v3

### DIFF
--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -7,10 +7,11 @@ const DEFAULT_OPTIONS = {
   tempFolderName: ".11ty-vite",
   viteOptions: {
     clearScreen: false,
+    appType: "custom",
     server: {
       // hmr: false,
       mode: "development",
-      middlewareMode: "ssr",
+      middlewareMode: true,
     },
     build: {
       mode: "production",

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module.exports = function(eleventyConfig) {
       clearScreen: false,
       server: {
         mode: "development",
-        middlewareMode: "ssr",
+        middlewareMode: true,
       },
       build: {
         mode: "production",


### PR DESCRIPTION

<img width="1283" alt="CleanShot 2022-07-15 at 21 28 15@2x" src="https://user-images.githubusercontent.com/7389358/179329310-c43b9ad4-a328-4f10-8bc4-facf0e1408db.png">


It seems Vite v3 deprecated `string` values for [`server.middlewareMode`](https://vitejs.dev/config/server-options.html#server-middlewaremode), it's a boolean now. The config value should be `true` now. 

Also, we need to add [`appType`](https://vitejs.dev/config/shared-options.html#apptype) as a shared config, the value should be `custom` according to the docs. 

Let me know if you want me to amend anything. 