### PR TITLE
Upgrade to vite@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".eleventy.js",
   "license": "MIT",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "funding": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   "homepage": "https://github.com/11ty/eleventy-plugin-vite/",
   "dependencies": {
     "lodash.merge": "^4.6.2",
-    "vite": "^3.0.0"
+    "vite": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".eleventy.js",
   "license": "MIT",
   "engines": {
-    "node": ">=14"
+    "node": ">=14.18.0"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
I had a look at the migration guides for vite@4 and rollup@3:
- https://vitejs.dev/guide/migration.html
- https://rollupjs.org/guide/en/#migration

Only change necessary (as far as I found it) was bumping the node engines field to 14, as rollup requires it.

Closes #19 