### PR TITLE
Workaround for renaming issue on Windows

### DIFF
--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -49,6 +49,9 @@ class EleventyVite {
     let tmp = path.resolve(".", this.options.tempFolderName);
 
     await fsp.mkdir(tmp, { recursive: true });
+    // The following line is a workaround. On Windows, renaming directoryA to directoryB throws an EPERM error if directoryB exists, even if it's empty.
+    // See https://github.com/nodejs/node/issues/21957#issuecomment-408486653.
+    await fsp.rm(tmp, { recursive: true, force: true });
     await fsp.rename(this.outputDir, tmp);
 
     try {


### PR DESCRIPTION
On Windows, renaming directoryA to directoryB throws an EPERM error if directoryB exists, even if it's empty. More details in https://github.com/nodejs/node/issues/21957#issuecomment-408486653.

This workaround removes the `tmp` folder before renaming `outputDir` to it. We cannot eliminate the preceding `mkdir` because it creates all the parent folders if needed.

Fixes #22, #32.