### PR TITLE
Use forward slash instead of `path.sep`

### DIFF
--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -59,11 +59,11 @@ class EleventyVite {
         .filter(entry => !!entry.outputPath) // filter out `false` serverless routes
         .filter(entry => (entry.outputPath || "").endsWith(".html")) // only html output
         .map(entry => {
-          if(!entry.outputPath.startsWith(this.outputDir + path.sep)) {
+          if(!entry.outputPath.startsWith(this.outputDir + "/")) {
             throw new Error(`Unexpected output path (was not in output directory ${this.outputDir}): ${entry.outputPath}`);
           }
 
-          return path.resolve(tmp, entry.outputPath.substr(this.outputDir.length + path.sep.length));
+          return path.resolve(tmp, entry.outputPath.substr(this.outputDir.length + "/".length));
         });
 
       viteOptions.build.outDir = path.resolve(".", this.outputDir);


### PR DESCRIPTION
Issue found in #22.


The issue is that `entry.outputPath` uses forward slashes even on Windows, therefore the condition always produces `false` with `path.sep` in the line:

```JavaScript
if(!entry.outputPath.startsWith(this.outputDir + path.sep)) {
```

There is a confirmation for this in the Eleventy repo: https://github.com/11ty/eleventy/blob/8e88b0786b4330182020dd0a7bc602ff774869f6/src/TemplatePermalink.js#L194

```javascript
    return normalize(outputDir + "/" + uri);
```

Thus, the path is combined using a forward slash, and not the `path.sep`. The `normalize` function from https://github.com/jonschlinkert/normalize-path is meant to “Normalize slashes in a file path to be posix/unix-like forward slashes.” Therefore, platform-specific separator cannot appear there even on Windows.