### PR TITLE
Dynamically import Vite

### DIFF
--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -1,6 +1,5 @@
 const { promises: fsp } = require("fs");
 const path = require("path");
-const { createServer: createViteServer, build: buildVite } = require("vite");
 const lodashMerge = require("lodash.merge");
 
 const DEFAULT_OPTIONS = {
@@ -36,6 +35,7 @@ class EleventyVite {
     let viteOptions = lodashMerge({}, this.options.viteOptions);
     viteOptions.root = this.outputDir;
 
+    const { createViteServer } = await import('vite');
     let vite = await createViteServer(viteOptions);
 
     return vite.middlewares;
@@ -68,6 +68,7 @@ class EleventyVite {
 
       viteOptions.build.outDir = path.resolve(".", this.outputDir);
 
+      const { createViteServer } = await import('vite');
       await buildVite(viteOptions);
     } catch(e) {
       console.warn( `[11ty] Encountered a Vite build error, restoring original Eleventy output to ${this.outputDir}`, e );

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -68,8 +68,8 @@ class EleventyVite {
 
       viteOptions.build.outDir = path.resolve(".", this.outputDir);
 
-      const { buildVite } = await import('vite');
-      await buildVite(viteOptions);
+      const { build } = await import('vite');
+      await build(viteOptions);
     } catch(e) {
       console.warn( `[11ty] Encountered a Vite build error, restoring original Eleventy output to ${this.outputDir}`, e );
       await fsp.rename(tmp, this.outputDir);

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -35,8 +35,8 @@ class EleventyVite {
     let viteOptions = lodashMerge({}, this.options.viteOptions);
     viteOptions.root = this.outputDir;
 
-    const { createViteServer } = await import('vite');
-    let vite = await createViteServer(viteOptions);
+    const { createServer } = await import('vite');
+    let vite = await createServer(viteOptions);
 
     return vite.middlewares;
   }

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -68,7 +68,7 @@ class EleventyVite {
 
       viteOptions.build.outDir = path.resolve(".", this.outputDir);
 
-      const { createViteServer } = await import('vite');
+      const { buildVite } = await import('vite');
       await buildVite(viteOptions);
     } catch(e) {
       console.warn( `[11ty] Encountered a Vite build error, restoring original Eleventy output to ${this.outputDir}`, e );


### PR DESCRIPTION
Vite will soon be dropping CJS support which means that you won't be able to `require` it. You either need to convert your code to ESM or dynamically import it. I've done the latter here for simplicity, but longer-term you'll probably want to convert to ESM rather than continuing to use the legacy CJS syntax