### PR TITLE
Upgrade to Vite v5, ESM, Eleventy 3

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,18 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const pkg = require('./package.json');
 
+/**
+ * Options which can be passed to eleventy-plugin-vite
+ * @typedef {Object} EleventyViteOptions
+ * @property {string} tempFolderName
+ * @property {import("vite").InlineConfig} [viteOptions]
+ * @property {Object} [serverOptions]
+ */
+
+/**
+ * @param {import('@11ty/eleventy/src/UserConfig').default} eleventyConfig
+ * @param {EleventyViteOptions} options
+ */
 export default function(eleventyConfig, options = {}) {
   try {
     eleventyConfig.versionCheck(pkg["11ty"].compatibility);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,7 +1,10 @@
-const pkg = require("./package.json");
-const EleventyVite = require("./EleventyVite");
+import EleventyVite from "./EleventyVite.js";
 
-module.exports = function(eleventyConfig, options = {}) {
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const pkg = require('./package.json');
+
+export default function(eleventyConfig, options = {}) {
   try {
     eleventyConfig.versionCheck(pkg["11ty"].compatibility);
   } catch(e) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,7 +11,7 @@ export default function(eleventyConfig, options = {}) {
     console.warn( `[11ty] Warning: Eleventy Plugin (${pkg.name}) Compatibility: ${e.message}` );
   }
 
-  let eleventyVite = new EleventyVite(eleventyConfig.dir.output, options);
+  let eleventyVite = new EleventyVite(eleventyConfig.directories, options);
 
   // Adds support for automatic publicDir passthrough copy
   // vite/rollup will not touch these files and as part of the build will copy them to the root of your output folder

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
-node_modules
+# Build results
+/example/_site/
+
+# IDEs
+/.idea/
+/.vscode/
+
+# Package managers
 package-lock.json
+/node_modules/
+.npm
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Artefacts
+.DS_Store

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -20,6 +20,7 @@ const DEFAULT_OPTIONS = {
       middlewareMode: true,
     },
     build: {
+      emptyOutDir: true,
       rollupOptions: {}, // we use this to inject input for MPA build below
     }
   }

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -1,6 +1,6 @@
 import { promises as fsp } from "node:fs";
 import path from "node:path";
-import lodashMerge from "lodash.merge";
+import { DeepCopy, Merge } from "@11ty/eleventy-utils";
 import { build, createServer } from "vite";
 
 const DEFAULT_OPTIONS = {
@@ -32,11 +32,11 @@ export default class EleventyVite {
 
   constructor(directories, pluginOptions = {}) {
     this.directories = directories;
-    this.options = lodashMerge({}, DEFAULT_OPTIONS, pluginOptions);
+    this.options = Merge({}, DEFAULT_OPTIONS, pluginOptions);
   }
 
   async getServerMiddleware() {
-    let viteOptions = lodashMerge({}, this.options.viteOptions);
+    let viteOptions = DeepCopy({}, this.options.viteOptions);
     viteOptions.root = this.directories.output;
 
     let vite = await createServer(viteOptions);
@@ -55,7 +55,7 @@ export default class EleventyVite {
     await fsp.rename(this.directories.output, tmp);
 
     try {
-      let viteOptions = lodashMerge({}, this.options.viteOptions);
+      let viteOptions = DeepCopy({}, this.options.viteOptions);
       viteOptions.root = tmp;
 
       viteOptions.build.rollupOptions.input = input

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -17,11 +17,9 @@ const DEFAULT_OPTIONS = {
     clearScreen: false,
     appType: "mpa",
     server: {
-      mode: "development",
       middlewareMode: true,
     },
     build: {
-      mode: "production",
       rollupOptions: {}, // we use this to inject input for MPA build below
     }
   }

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -51,7 +51,6 @@ export default class EleventyVite {
   async runBuild(input) {
     let tmp = path.resolve(this.directories.input, this.options.tempFolderName);
 
-    await fsp.mkdir(tmp, { recursive: true });
     await fsp.rename(this.directories.output, tmp);
 
     try {

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { DeepCopy, Merge } from "@11ty/eleventy-utils";
 import { build, createServer } from "vite";
 
+/** @type {Required<import(".eleventy.js").EleventyViteOptions>} */
 const DEFAULT_OPTIONS = {
   tempFolderName: ".11ty-vite",
   viteOptions: {
@@ -30,12 +31,16 @@ export default class EleventyVite {
   /** @type {import("@11ty/eleventy/src/Util/ProjectDirectories.js").default} */
   directories;
 
+  /** @type {Required<import(".eleventy.js").EleventyViteOptions>} */
+  options;
+
   constructor(directories, pluginOptions = {}) {
     this.directories = directories;
     this.options = Merge({}, DEFAULT_OPTIONS, pluginOptions);
   }
 
   async getServerMiddleware() {
+    /** @type {import("vite").InlineConfig} */
     let viteOptions = DeepCopy({}, this.options.viteOptions);
     viteOptions.root = this.directories.output;
 
@@ -54,6 +59,7 @@ export default class EleventyVite {
     await fsp.rename(this.directories.output, tmp);
 
     try {
+      /** @type {import("vite").InlineConfig} */
       let viteOptions = DeepCopy({}, this.options.viteOptions);
       viteOptions.root = tmp;
 

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -1,6 +1,7 @@
-const { promises: fsp } = require("fs");
-const path = require("path");
-const lodashMerge = require("lodash.merge");
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+import lodashMerge from "lodash.merge";
+import { build, createServer } from "vite";
 
 const DEFAULT_OPTIONS = {
   tempFolderName: ".11ty-vite",
@@ -35,7 +36,6 @@ class EleventyVite {
     let viteOptions = lodashMerge({}, this.options.viteOptions);
     viteOptions.root = this.outputDir;
 
-    const { createServer } = await import('vite');
     let vite = await createServer(viteOptions);
 
     return vite.middlewares;
@@ -68,7 +68,6 @@ class EleventyVite {
 
       viteOptions.build.outDir = path.resolve(".", this.outputDir);
 
-      const { build } = await import('vite');
       await build(viteOptions);
     } catch(e) {
       console.warn( `[11ty] Encountered a Vite build error, restoring original Eleventy output to ${this.outputDir}`, e );
@@ -81,4 +80,3 @@ class EleventyVite {
   }
 }
 
-module.exports = EleventyVite;

--- a/EleventyVite.js
+++ b/EleventyVite.js
@@ -7,13 +7,6 @@ import { build, createServer } from "vite";
 const DEFAULT_OPTIONS = {
   tempFolderName: ".11ty-vite",
   viteOptions: {
-    resolve:{
-      alias:{
-        // Allow references to `node_modules` directly for bundling.
-        '/node_modules': path.resolve(".", 'node_modules')
-        // Note that bare module specifiers are also supported
-      },
-    },
     clearScreen: false,
     appType: "mpa",
     server: {
@@ -22,7 +15,14 @@ const DEFAULT_OPTIONS = {
     build: {
       emptyOutDir: true,
       rollupOptions: {}, // we use this to inject input for MPA build below
-    }
+    },
+    resolve:{
+      alias:{
+        // Allow references to `node_modules` directly for bundling.
+        '/node_modules': path.resolve(".", 'node_modules')
+        // Note that bare module specifiers are also supported
+      },
+    },
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -51,25 +51,25 @@ module.exports = function(eleventyConfig) {
     tempFolderName: ".11ty-vite", // Default name of the temp folder
 
     // Options passed to the Eleventy Dev Server
-    // e.g. domdiff, enabled, etc.
-    // Added in Vite plugin v2.0.0
-    serverOptions: {},
+    // Defaults
+    serverOptions: {
+        module: "@11ty/eleventy-dev-server",
+        domDiff: false,
+    },
 
-    // defaults are shown
+    // Defaults
     viteOptions: {
       clearScreen: false,
-      appType: "mpa", // New in v2.0.0
+      appType: "mpa",
 
       server: {
-        mode: "development",
         middlewareMode: true,
       },
 
       build: {
-        mode: "production",
+          emptyOutDir: true,
       },
 
-      // New in v2.0.0
       resolve: {
         alias: {
           // Allow references to `node_modules` folder directly

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # eleventy-plugin-vite 🕚⚡️🎈🐀
 
-A plugin to use [Vite v4.0](https://vitejs.dev/) with Eleventy v2.0.
+A plugin to use [Vite v5.0](https://vitejs.dev/) with Eleventy v3.0.
 
 This plugin:
 
@@ -17,7 +17,8 @@ This plugin:
 ## Eleventy Housekeeping
 
 - Please star [Eleventy on GitHub](https://github.com/11ty/eleventy/)!
-- Follow us on Twitter [@eleven_ty](https://twitter.com/eleven_ty)
+- Follow us on Mastodon [@eleventy@fosstodon.org](https://fosstodon.org/@eleventy) or Twitter [@eleven_ty](https://twitter.com/eleven_ty)
+- Join us on [Discord](https://www.11ty.dev/blog/discord/)
 - Support [11ty on Open Collective](https://opencollective.com/11ty)
 - [11ty on npm](https://www.npmjs.com/org/11ty)
 - [11ty on GitHub](https://github.com/11ty)

--- a/example/.eleventy.js
+++ b/example/.eleventy.js
@@ -1,0 +1,7 @@
+import EleventyVitePlugin from "../.eleventy.js"
+
+export default function(eleventyConfig) {
+  eleventyConfig.addPassthroughCopy(`${eleventyConfig.directories.input}assets/`);
+
+  eleventyConfig.addPlugin(EleventyVitePlugin);
+};

--- a/example/assets/main.css
+++ b/example/assets/main.css
@@ -1,0 +1,7 @@
+body {
+  background-color: black;
+}
+
+h1 {
+  color: white;
+}

--- a/example/index.njk
+++ b/example/index.njk
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Eleventy Plugin Vite</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <link rel="stylesheet" href="{{ '/assets/main.css' | url }}" />
+  </head>
+
+  <body>
+    <h1>Eleventy Plugin Vite</h1>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "homepage": "https://github.com/11ty/eleventy-plugin-vite/",
   "dependencies": {
     "lodash.merge": "^4.6.2",
-    "vite": "^4.0.4"
+    "vite": "^5.2.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@11ty/eleventy-utils": "^1.0.3",
-    "vite": "^5.2.13"
+    "vite": "^5.3.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "3.0.0-alpha.6"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "@11ty/eleventy-plugin-vite",
-  "type": "module",
   "version": "4.0.0",
   "description": "A plugin to use Vite as a development server and run Vite to postprocess your Eleventy build.",
-  "main": ".eleventy.js",
   "license": "MIT",
   "engines": {
     "node": ">=18"
@@ -33,6 +31,17 @@
   },
   "bugs": "https://github.com/11ty/eleventy-plugin-vite/issues",
   "homepage": "https://github.com/11ty/eleventy-plugin-vite/",
+  "main": "./.eleventy.js",
+  "type": "module",
+  "exports": {
+    ".": "./.eleventy.js",
+    "./EleventyVite": "./EleventyVite.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    ".eleventy.js",
+    "EleventyVite.js"
+  ],
   "scripts": {
     "example": "npx @11ty/eleventy --config=example/.eleventy.js --input=example --output=example/_site",
     "example:start": "npm run example -- --serve",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,17 @@
   },
   "bugs": "https://github.com/11ty/eleventy-plugin-vite/issues",
   "homepage": "https://github.com/11ty/eleventy-plugin-vite/",
+  "scripts": {
+    "example": "npx @11ty/eleventy --config=example/.eleventy.js --input=example --output=example/_site",
+    "example:start": "npm run example -- --serve",
+    "example:build": "npm run example",
+    "example:clean": "rimraf ./example/_site"
+  },
   "dependencies": {
     "lodash.merge": "^4.6.2",
     "vite": "^5.2.13"
+  },
+  "devDependencies": {
+    "@11ty/eleventy": "3.0.0-alpha.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "example:clean": "rimraf ./example/_site"
   },
   "dependencies": {
-    "lodash.merge": "^4.6.2",
+    "@11ty/eleventy-utils": "^1.0.3",
     "vite": "^5.2.13"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "server"
   ],
   "11ty": {
-    "compatibility": ">=2.0.0-canary.32"
+    "compatibility": ">=3.0.0-alpha.6"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@11ty/eleventy-plugin-vite",
+  "type": "module",
   "version": "4.0.0",
   "description": "A plugin to use Vite as a development server and run Vite to postprocess your Eleventy build.",
   "main": ".eleventy.js",
   "license": "MIT",
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=18"
   },
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
With the changes to directory normalization of `@11ty/eleventy` >= `3.0.0-alpha.6` the plugin started to break. While fixing the problem I also made the following upgrades:

- Switch to ESM
- Use new `directories` from `@11ty/eleventy@3.0.0-alpha.6`
- Upgrade to Vite v5
- Add an example for testing
- Updated the path resolving to work with input directory set via CLI
- Replace `lodash` with `@11ty/eleventy-utils`
- Add some JSDoc types
- Remove some nonexisting vite options

This should probably be released as v5.